### PR TITLE
Removes the lodash dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/**
 **.DS_Store
+npm-debug.log
+.idea/

--- a/lib/animation.js
+++ b/lib/animation.js
@@ -1,5 +1,4 @@
 var utils = require('./utils');
-var _ = require('lodash');
 // Basically a buffer with utilities
 // This is how we will create animation frames and string them together
 // It's best to save these in a variable or object for later use
@@ -12,7 +11,7 @@ function Animation (framelength, numberOfFrames, intensity) {
   this.framelength = framelength || 1;
   // Range of frames for looping purposes
   // Exposes frames.length which is also useful for animation creation
-  this.frames = numberOfFrames ? _.range(numberOfFrames) : _.range(1);
+  this.frames = numberOfFrames ? range(numberOfFrames) : range(0);
   // Initialize buffer of appropriate length
   // We multiply by three since each pixel has an r, g, and b value
   var buffer = new Buffer(this.framelength*this.frames.length*3);
@@ -37,7 +36,7 @@ function setColor(buffer, index, color){
 Animation.prototype.setPixel = function(index, color, frame) {
   var color = utils.convertToRGB(color);
   if(frame === undefined){
-    _.each(this.frames, function(frame){
+    each(this.frames, function(frame){
       setColor(this.buffer, frame * this.framelength + index, color);
     },this);
   }
@@ -53,11 +52,11 @@ Animation.prototype.setAll = function (color, frame) {
   var color = utils.convertToRGB(color);
   var buffer = this.buffer;
   if(frame === undefined){
-    _.each( _.range(this.framelength*this.frames.length), function(pixelIndex){
+    each( range(this.framelength*this.frames.length), function(pixelIndex){
       setColor(buffer, pixelIndex, color);
     },this);
   }else{
-    _.each( _.range(this.framelength), function(pixelIndex){
+    each( range(this.framelength), function(pixelIndex){
       setColor(buffer, frame * this.framelength + pixelIndex, color);
     },this);
   }
@@ -67,20 +66,45 @@ Animation.prototype.setAll = function (color, frame) {
 // Sets a repeating pattern to the frame
 // If no frame is specified it'll set the pattern to all frames
 Animation.prototype.setPattern = function(colors, frame){
-  var colors = _.map(colors, utils.convertToRGB);
-  var pixels = _.range(this.framelength);
+  var colors = map(colors, utils.convertToRGB);
+  var pixels = range(this.framelength);
   var frames = this.frames;
   if(frame === undefined){
-    _.forEach(pixels, function(pixel, index){
+    each(pixels, function(pixel, index){
       this.setPixel(index,colors[index%colors.length]);
     },this);
   }
   else {
-    _.forEach(pixels, function(pixel, index){
+    each(pixels, function(pixel, index){
       this.setPixel( pixels.length * frame + index, colors[index%colors.length], frame);
     },this);
   }
   return this;
 };
+
+// Instead of lodash
+function range(end) {
+  var result = new Array(end);
+  for (var i=0; i< end; i++) {
+    result[i] = i;
+  }
+  return result;
+}
+
+function each(arr, cb) {
+  for (var i in arr) {
+    if (arr.hasOwnProperty(i)) {
+      cb(arr[i]);
+    }
+  }
+}
+
+function map(arr, cb) {
+  var result = new Array(arr.length);
+  for (var i=0; i<arr.length; i++) {
+    result[i] = cb(arr[i]);
+  }
+  return result;
+}
 
 module.exports = Animation;

--- a/lib/animation.js
+++ b/lib/animation.js
@@ -92,10 +92,8 @@ function range(end) {
 }
 
 function each(arr, cb) {
-  for (var i in arr) {
-    if (arr.hasOwnProperty(i)) {
-      cb(arr[i]);
-    }
+  for (var i=0; i<arr.length; i++) {
+    cb(i, arr[i]);
   }
 }
 

--- a/lib/animation.js
+++ b/lib/animation.js
@@ -91,16 +91,16 @@ function range(end) {
   return result;
 }
 
-function each(arr, cb) {
+function each(arr, cb, that) {
   for (var i=0; i<arr.length; i++) {
-    cb(i, arr[i]);
+    cb.call(that, i, arr[i]);
   }
 }
 
-function map(arr, cb) {
+function map(arr, cb, that) {
   var result = new Array(arr.length);
   for (var i=0; i<arr.length; i++) {
-    result[i] = cb(arr[i]);
+    result[i] = cb.call(that, arr[i]);
   }
   return result;
 }

--- a/lib/npx.js
+++ b/lib/npx.js
@@ -2,13 +2,13 @@ var hw = process.binding('hw'); // Comment this and promisifyAnimation out to ru
 var util = require('util');
 var events = require('events');
 var Q = require('kew');
-var Animation = require('./animation')
+var Animation = require('./animation');
 
 function promisifyAnimation(animation, delay) {
   // Return a function that returns a promise so make api cleaner
   return function() {
-    var deferred = Q.defer()
-      // Animation done, resolve promise and do next thing
+    var deferred = Q.defer();
+    // Animation done, resolve promise and do next thing
     setTimeout(function() {
       // We pass this along just in case the next promise needs it.
       deferred.resolve(animation);
@@ -51,7 +51,7 @@ Npx.prototype.enqueue = function(animation, delay) {
 // Run animations in queue
 Npx.prototype.run = function() {
   var deferred = Q.defer()
-    // Recursive run function passing along the index to optimize for long queues.
+  // Recursive run function passing along the index to optimize for long queues.
   var run = function(index) {
     if (index === undefined) {
       index = 0;
@@ -61,13 +61,13 @@ Npx.prototype.run = function() {
       // Instead of using unshift here we just inspect
       // This is an optimization for long queues
       animation()
-        .then(function() {
-          run(++index);
-        });
+          .then(function() {
+            run(++index);
+          });
     } else {
       this.running = false;
       // Clear the queue since we're inspecting instead of unshift
-      queue = [];
+      this.clear();
       deferred.resolve();
     }
   }.bind(this);
@@ -91,18 +91,22 @@ Npx.prototype.loop = function() {
       // Instead of using unshift here we just inspect
       // This is an optimization for long queues
       animation()
-        .then(function() {
-          run(++index);
-        });
+          .then(function() {
+            run(++index);
+          });
     } else {
       this.running = false;
       // Clear the queue since we're inspecting instead of unshift
-      queue = [];
+      this.clear();
     }
   }.bind(this);
   // Execute all items in queue.
   this.running = true;
   run(0);
+};
+
+Npx.prototype.clear = function() {
+  this.queue = [];
 };
 
 // Under development

--- a/lib/npx.js
+++ b/lib/npx.js
@@ -49,8 +49,8 @@ Npx.prototype.enqueue = function(animation, delay) {
 };
 
 // Run animations in queue
-Npx.prototype.run = function() {
-  var deferred = Q.defer()
+Npx.prototype.run = function(keepQueue) {
+  var deferred = Q.defer();
   // Recursive run function passing along the index to optimize for long queues.
   var run = function(index) {
     if (index === undefined) {
@@ -67,7 +67,7 @@ Npx.prototype.run = function() {
     } else {
       this.running = false;
       // Clear the queue since we're inspecting instead of unshift
-      this.clear();
+      if (!keepQueue) { this.clear(); }
       deferred.resolve();
     }
   }.bind(this);
@@ -78,7 +78,7 @@ Npx.prototype.run = function() {
 };
 
 // Beta, not entirely stable
-Npx.prototype.loop = function() {
+Npx.prototype.loop = function(keepQueue) {
   var run = function(index) {
     if (index === undefined) {
       index = 0;
@@ -97,7 +97,7 @@ Npx.prototype.loop = function() {
     } else {
       this.running = false;
       // Clear the queue since we're inspecting instead of unshift
-      this.clear();
+      if (!keepQueue) { this.clear(); }
     }
   }.bind(this);
   // Execute all items in queue.
@@ -109,9 +109,12 @@ Npx.prototype.clear = function() {
   this.queue = [];
 };
 
-// Under development
-Npx.prototype.stop = function() {
+Npx.prototype.pause = function() {
   this.running = false;
+};
+
+Npx.prototype.stop = function() {
+  this.pause();
   this.clear();
 };
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   },
   "homepage": "https://github.com/HarleyKwyn/npx",
   "dependencies": {
-    "kew": "^0.5.0-alpha.1",
-    "lodash": "^2.4.1"
+    "kew": "^0.5.0-alpha.1"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
The `lodash` library can not be compiled and installed to the Tessel 1, so this PR removes lodash completely and replaces the used functions with naive local implementations.

Also implements a `clear` function.
